### PR TITLE
repositioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ The XMTP protocol brings the same security gurantees as Signal and both are audi
 ## Integration Language
 When implementing the XMTP protocol or referencing the protocol in language, it should read as:
 
-<img src="https://github.com/xmtp/brand/blob/main/guideassets/badgeUseExampleHorizontal-InText.jpg?raw=true">
-
 *Secured by XMTP*
 
 Use the provided graphics and treatments in-app:
@@ -37,6 +35,10 @@ Use the provided graphics and treatments in-app:
 
 <img src="https://github.com/xmtp/brand/blob/main/guideassets/badgeExampleHorizontal.jpg?raw=true">
 <img src="https://github.com/xmtp/brand/blob/main/guideassets/badgeUseExampleHorizontal.jpg?raw=true">
+
+*Recommended uses in-app*
+
+<img src="https://github.com/xmtp/brand/blob/main/guideassets/badgeUseExampleHorizontal-InText.jpg?raw=true">
 <img src="https://github.com/xmtp/brand/blob/main/guideassets/badgeUseExampleHorizontal-InApp.jpg?raw=true">
 
 # Logo Construction


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Reposition the horizontal in-text badge image in [README.md](https://github.com/xmtp/brand/pull/14/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to a new italicized 'Recommended uses in-app' subsection under 'Integration Language'
Moves the in-text badge image from the 'Integration Language' section to a new italicized 'Recommended uses in-app' subsection in [README.md](https://github.com/xmtp/brand/pull/14/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) and reorders related image references.

#### 📍Where to Start
Start with the 'Integration Language' section and the new 'Recommended uses in-app' subsection in [README.md](https://github.com/xmtp/brand/pull/14/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 117347a.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->